### PR TITLE
Fix to session cookie mismatch in a specific domain setup

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -655,7 +655,7 @@ class auth_plugin_drupalservices extends auth_plugin_base
         }
         $session_name=$cfg->cookiedomain;
 
-        $session_name = $prefix . substr(hash('sha256', '.'.$session_name), 0, 32);
+        $session_name = $prefix . substr(hash('sha256', $session_name), 0, 32);
         if (isset($_COOKIE[$session_name])) {
             $session_id = $_COOKIE[$session_name];
             $return = array('session_name' => $session_name, 'session_id' => $session_id,);


### PR DESCRIPTION
Fixing an issue where session cookie is not found if Drupal is installed under base domain (example.com, without www) and Moodle in a subdomain (moodle.example.com). Assuming a custom cookie domain is not used, Drupal does not hard code the leading dot in the session cookie hash, so this Moodle plugin should mirror that behavior.

I found this out by accident while having no write access to Drupal's settings.php and trying to understand the issue instead of working around it by setting a custom cookie domain. I am not sure it covers all possible circumstances, but it got my integration to work.
