### PR TITLE
Additional error handling / feedback + CSRF token get before login

### DIFF
--- a/REST-API.php
+++ b/REST-API.php
@@ -180,7 +180,7 @@ class RemoteAPI {
     $ret->error    = curl_error($ch);
     $ret->info     = curl_getinfo($ch);
     curl_close($ch);
-   
+
     if ($ret->info['http_code'] == 200) {
       $ret->response = json_decode($ret->response);
     }
@@ -251,7 +251,7 @@ class RemoteAPI {
   // *****************************************************************************
   // Logout: uses the cURL library to handle logout
   public function Logout() {
-   
+
     $callerId = 'RemoteAPI->Logout';
     if (!$this->VerifyLoggedIn( $callerId )) {
       return NULL; // error
@@ -261,6 +261,9 @@ class RemoteAPI {
 
     $ret = $this->CurlHttpRequest($callerId, $url, 'POST', NULL, true, true);
     if ($ret->info['http_code'] != 200) {
+      if (!empty($ret->error)) {
+        print $ret->error . PHP_EOL;
+      }
       return NULL;
     }
     else {
@@ -282,7 +285,7 @@ class RemoteAPI {
     if (!$this->VerifyLoggedIn( $callerId )) {
       return NULL; // login error
     }
-   
+
     $url = $this->gateway.$this->endpoint.'/'.$resourceType . $options;
     $ret = $this->CurlHttpRequest($callerId, $url, 'GET', NULL, true);
     if($debug){

--- a/auth.php
+++ b/auth.php
@@ -255,6 +255,13 @@ class auth_plugin_drupalservices extends auth_plugin_base
         if ($ret->info['http_code']==401) {
           die("ERROR: Login failed - check username and password!\n");
         }
+        elseif ($ret->info['http_code']!==200) {
+          $error = "ERROR: Login to drupal failed with http code " . $ret->info['http_code'];
+          if (!empty($ret->error)) {
+            $error .= PHP_EOL . $ret->error . PHP_EOL;
+          }
+          die($error);
+        }
         // list external users
         $drupal_users = $apiObj->Index('muser');
         if (is_null($drupal_users) || empty($drupal_users)) {
@@ -481,6 +488,12 @@ class auth_plugin_drupalservices extends auth_plugin_base
           }
           elseif($ret->info['http_code']==200){
             $tests['auth']=array('success'=>true, 'message'=> "user/login: Logged in to drupal!");
+          }
+          else {
+            $tests['auth']=array('success'=>false, 'message'=> "user/login: Login to drupal failed with http code " . $ret->info['http_code']);
+            if (!empty($ret->error)) {
+              $tests['auth']['message'] .= PHP_EOL . $ret->error;
+            }
           }
 
           //test #4: user listings


### PR DESCRIPTION
After testing a lot with a standalone REST client I noticed that logins fail when doing it multiple times. This can be fixed by getting and using a CSRF token beforehand.
