### PR TITLE
Issue #46: Logout doesn't log out of drupal

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -234,7 +234,8 @@ debugging("<pre>the user that should have been created or updated is:\r\n".print
         global $CFG, $SESSION;
         $base_url = $this->config->host_uri;
         if ($drupalsession=$this->get_drupal_session() ) {
-          if (get_config('call_logout_service', 'auth_drupalservices')) {
+          if ($this->config->call_logout_service) {
+            //die("trying to log out");
             // logout of drupal.
             $apiObj = new RemoteAPI($base_url, 1, $drupalsession);
             $ret = $apiObj->Logout();


### PR DESCRIPTION
The test to determine whether or not to log out of drupal when
moodle users hit logout doesn't work. This should be fixed now.