### PR TITLE
auth.php PHP 7 error code fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.project
+/.settings/

--- a/auth.php
+++ b/auth.php
@@ -167,7 +167,7 @@ debugging("<pre>the user that should have been created or updated is:\r\n".print
 
         if (empty($user)) {
           // build the new user object to be put into the Moodle database
-          $user = new object();
+          $user = new stdClass();
         }
         //fixed value fields (modified could probably stand to be adjusted)
         $user->auth = $this->authtype;


### PR DESCRIPTION
PHP 7 throws error for the code `$user = new object();` it should be changed to `$user = new stdClass();` as per the recommendation here http://php.net/manual/en/reserved.classes.php

